### PR TITLE
tcp tracer implementation

### DIFF
--- a/vendor/github.com/iovisor/iomodules/hover/bpf/bpf_module.go
+++ b/vendor/github.com/iovisor/iomodules/hover/bpf/bpf_module.go
@@ -195,9 +195,7 @@ func (bpf *BpfModule) load(name string, progType int) (int, error) {
 
 var kprobeRegexp = regexp.MustCompile("[+.]")
 
-func (bpf *BpfModule) AttachKprobe(event string, fd int) error {
-	evName := "p_" + kprobeRegexp.ReplaceAllString(event, "_")
-	desc := fmt.Sprintf("p:kprobes/%s %s", evName, event)
+func (bpf *BpfModule) attachProbe(evName, desc string, fd int) error {
 	if _, ok := bpf.kprobes[evName]; ok {
 		return nil
 	}
@@ -212,7 +210,22 @@ func (bpf *BpfModule) AttachKprobe(event string, fd int) error {
 		return fmt.Errorf("Failed to attach BPF kprobe")
 	}
 	bpf.kprobes[evName] = res
+
 	return nil
+}
+
+func (bpf *BpfModule) AttachKprobe(event string, fd int) error {
+	evName := "p_" + kprobeRegexp.ReplaceAllString(event, "_")
+	desc := fmt.Sprintf("p:kprobes/%s %s", evName, event)
+
+	return bpf.attachProbe(evName, desc, fd)
+}
+
+func (bpf *BpfModule) AttachKretprobe(event string, fd int) error {
+	evName := "r_" + kprobeRegexp.ReplaceAllString(event, "_")
+	desc := fmt.Sprintf("r:kprobes/%s %s", evName, event)
+
+	return bpf.attachProbe(evName, desc, fd)
 }
 
 func (bpf *BpfModule) TableSize() uint64 {


### PR DESCRIPTION
This implements the [basic tcpv4tracer](https://github.com/kinvolk/bcc/tree/iaguis/tcp_tracer) in golang using libbcc.